### PR TITLE
3 pwm

### DIFF
--- a/include/amc6821.h
+++ b/include/amc6821.h
@@ -1,6 +1,6 @@
 /**
  * @file amc6821.h
- * @author Nick DePatie and Dylan Donahue
+ * @author Nick DePatie, Dylan Donahue, and David Meseonznik
  * @brief 
  * @date 2022-03-14
  */
@@ -47,7 +47,7 @@
 #define AMC6821_CHARACTERISTICS_REG         0x20
 
 //PWM Frequencies type
-typedef enum
+typedef enum pwmfreq_t
 {
     AMC6821_CHARACTERISTICS_1KHZ,
     AMC6821_CHARACTERISTICS_10KHZ,
@@ -55,10 +55,10 @@ typedef enum
     AMC6821_CHARACTERISTICS_25KHZ,          //(default) frequency for our fans
     AMC6821_CHARACTERISTICS_30KHZ,
     AMC6821_CHARACTERISTICS_40KHZ           //0x06 and 0x07 also result in 40kHz duty cycle
-}pwmfreq_t;
+};
 
 //Fan spin up times type
-typedef enum
+typedef enum fanspinuptime_t
 {
     AMC6821_CHARACTERISTICS_SPINUP_02,      //02 means 0.2 seconds
     AMC6821_CHARACTERISTICS_SPINUP_04,      //04 means 0.4 seconds
@@ -68,7 +68,7 @@ typedef enum
     AMC6821_CHARACTERISTICS_SPINUP_2,       //(default)
     AMC6821_CHARACTERISTICS_SPINUP_4,
     AMC6821_CHARACTERISTICS_SPINUP_8 
-}fanspinuptime_t;
+};
 
 /*********************************************************************************************/
 
@@ -81,13 +81,14 @@ class AMC6821
          */
         union
         {
-            uint8_t *msg;
+            uint8_t msg;
+
             struct
             {
-                uint8_t fanspinup_enable        :1;
-                uint8_t reserved                :1;
-                pwmfreq_t pwmfreq               :3;
                 fanspinuptime_t fanspinuptime   :3;
+                pwmfreq_t pwmfreq               :3;
+                uint8_t reserved                :1;
+                uint8_t fanspinup_enable        :1;
             } bitfieldmsg;
         }characteristicsmsg;
 

--- a/include/amc6821.h
+++ b/include/amc6821.h
@@ -82,7 +82,6 @@ class AMC6821
         union
         {
             uint8_t *msg;
-
             struct
             {
                 uint8_t fanspinup_enable        :1;
@@ -176,20 +175,6 @@ class AMC6821
         void getCharacteristics();
 
         /**
-         * @brief Reading the Configuration 2 Register
-         * 
-         * @return uint8_t* 
-         */
-        uint8_t getConfig2Reg();
-
-        /**
-         * @brief Set the Configuration 2 Register
-         * 
-         * @param config 
-         */
-        void setConfig2Reg(uint8_t config);
-
-        /**
          * @brief Resets the registers of the AMC6821
          * @note Essentially behaves like a soft power cycle
          * 
@@ -203,5 +188,12 @@ class AMC6821
          * @param config 
          */
         void writeConfig(uint8_t configNum, uint8_t config);
+        /**
+         * @brief Reads specified config register
+         * 
+         * @param configNum 
+         * @param msg 
+         */
+        void readConfig(uint8_t *msg, uint8_t configNum);        
 };
 #endif

--- a/include/amc6821.h
+++ b/include/amc6821.h
@@ -47,7 +47,7 @@
 #define AMC6821_CHARACTERISTICS_REG         0x20
 
 //PWM Frequencies type
-typedef enum pwmfreq_t
+enum pwmfreq_t
 {
     AMC6821_CHARACTERISTICS_1KHZ,
     AMC6821_CHARACTERISTICS_10KHZ,
@@ -58,7 +58,7 @@ typedef enum pwmfreq_t
 };
 
 //Fan spin up times type
-typedef enum fanspinuptime_t
+enum fanspinuptime_t
 {
     AMC6821_CHARACTERISTICS_SPINUP_02,      //02 means 0.2 seconds
     AMC6821_CHARACTERISTICS_SPINUP_04,      //04 means 0.4 seconds

--- a/include/amc6821.h
+++ b/include/amc6821.h
@@ -146,7 +146,7 @@ class AMC6821
          * 
          * @param fanspinup_toggle 
          */
-        void enableFanSpinup(bool fanspinup_toggle);
+        void disableFanSpinup(bool fanspinup_toggle);
 
         /**
          * @brief Set the Fan Spin Up Time

--- a/include/amc6821.h
+++ b/include/amc6821.h
@@ -180,7 +180,7 @@ class AMC6821
          * 
          * @return uint8_t* 
          */
-        uint8_t *getConfig2Reg();
+        uint8_t getConfig2Reg();
 
         /**
          * @brief Set the Configuration 2 Register
@@ -197,12 +197,11 @@ class AMC6821
         void resetChip();
 
         /**
-         * @brief Writes to the specified config register the desired config
+         * @brief Writes to the specified config register
          * 
          * @param configNum 
          * @param config 
          */
         void writeConfig(uint8_t configNum, uint8_t config);
 };
-
 #endif

--- a/include/nerduino.h
+++ b/include/nerduino.h
@@ -135,6 +135,12 @@ class NERDUINO
          * @param numReadings
          */
         void getSHTdata(HumidData_t *humidbuf, uint8_t numReadings);
+        /**
+         * @brief write the passed dutycycle 
+         * 
+         * @param dutycycle
+         */
+        void setAMCDutyCycle(uint8_t dutyCycle);
 };
 
 extern NERDUINO NERduino;

--- a/include/nerduino.h
+++ b/include/nerduino.h
@@ -136,11 +136,18 @@ class NERDUINO
          */
         void getSHTdata(HumidData_t *humidbuf, uint8_t numReadings);
         /**
-         * @brief write the passed dutycycle 
+         * @brief write the passed dutycycle to the AMC duty cycle register
          * 
          * @param dutycycle
          */
         void setAMCDutyCycle(uint8_t dutyCycle);
+        /**
+         * @brief sets the pwm frequency of the AMC duty cycle
+         * @note take a value from 0 to 5 corresponsing to 1kHz, 10kHz, 20kHz, 25kHz, 30kHz, and 40kHz
+         * 
+         * @param pwmFreq (0-5)
+         */
+        void setAMCPWMFreq(pwmfreq_t pwmFreq);
 };
 
 extern NERDUINO NERduino;

--- a/src/amc6821.cpp
+++ b/src/amc6821.cpp
@@ -9,12 +9,13 @@ AMC6821::AMC6821()
     {
         Serial.println("AMC6821 PWM Chip connected");
         resetChip();
-        getCharacteristics();
         delay(10);
         writeConfig(1, 0x08);
         writeConfig(2, 0x03);
         writeConfig(3, 0x02);
         writeConfig(4, 0x88);
+        disableFanSpinup(true);
+        getCharacteristics();
         return;
     }
     Serial.println("~~~~~~~~~~~~~~~~WARNING: Unable to verify functionality of AMC6821~~~~~~~~~~~~~~~~~~~~~~~");
@@ -92,7 +93,7 @@ void AMC6821::enablePWM(bool pwm_toggle)
     writeConfig(2, newconfig2);
 }
 
-void AMC6821::enableFanSpinup(bool fanspinup_toggle)
+void AMC6821::disableFanSpinup(bool fanspinup_toggle)
 {
     characteristicsmsg.bitfieldmsg.fanspinup_enable = fanspinup_toggle;
     setCharacteristics();

--- a/src/amc6821.cpp
+++ b/src/amc6821.cpp
@@ -78,7 +78,7 @@ void AMC6821::enablePWM(bool pwm_toggle)
 {
     uint8_t msg[1];
     readConfig(msg, 2);
-    if (msg[0] == NULL)
+    if (msg == NULL)
     {
         Serial.println("PWM Toggle not successful");
         return;
@@ -133,7 +133,7 @@ void AMC6821::getCharacteristics()
 {
     uint8_t cmd[1] = {AMC6821_CHARACTERISTICS_REG};
     AMC6821write(cmd,1);
-    AMC6821read(characteristicsmsg.msg, 1);
+    AMC6821read(&characteristicsmsg.msg, 1);
     return;
 }
 
@@ -165,7 +165,7 @@ void AMC6821::writeConfig(uint8_t configNum, uint8_t config)
       break;
     default:
       Serial.println("Unidentified Config #!");
-      break;
+      return;
   }
   
   AMC6821write(cmd,2);
@@ -178,20 +178,21 @@ void AMC6821::readConfig(uint8_t *msg, uint8_t configNum)
   switch(configNum)
   {
     case 1:
-      cmd[0] =  AMC6821_CONFIG1_REG;
-      break;
+        cmd[0] =  AMC6821_CONFIG1_REG;
+        break;
     case 2:
-      cmd[0] =  AMC6821_CONFIG2_REG;
-      break;
+        cmd[0] =  AMC6821_CONFIG2_REG;
+        break;
     case 3:
-      cmd[0] =  AMC6821_CONFIG3_REG;
-      break;
+        cmd[0] =  AMC6821_CONFIG3_REG;
+        break;
     case 4:
-      cmd[0] =  AMC6821_CONFIG4_REG;
-      break;
+        cmd[0] =  AMC6821_CONFIG4_REG;
+        break;
     default:
-      Serial.println("Unidentified Config #!");
-      break;
+        Serial.println("Unidentified Config #!");
+        msg = NULL;
+        return;
   }
   AMC6821write(cmd, 1);
   AMC6821read(msg,1);

--- a/src/amc6821.cpp
+++ b/src/amc6821.cpp
@@ -7,11 +7,10 @@ AMC6821::AMC6821()
     
     if(verifyFunctionality())
     {
-      u_int8_t msg[1];
         Serial.println("AMC6821 PWM Chip connected");
         resetChip();
         getCharacteristics();
-        delay(50);
+        delay(10);
         writeConfig(1, 0x08);
         writeConfig(2, 0x03);
         writeConfig(3, 0x02);
@@ -140,6 +139,8 @@ void AMC6821::getCharacteristics()
 void AMC6821::resetChip()
 {
   writeConfig(2, 0x80);
+  characteristicsmsg.msg = 29;
+  setCharacteristics();
 }
 
 void AMC6821::writeConfig(uint8_t configNum, uint8_t config)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,12 @@ void loop(){
     Serial.print(humidbuf[i].relHumid);
     Serial.println(" %RH");
   }
-  
+
+  NERduino.setAMCDutyCycle(0x00);
+  delay(1000);
+  NERduino.setAMCDutyCycle(0xFF);
+
   Serial.println("cycle...");
 
-  delay(1000);
+  delay(5000);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,7 @@ void setup() {
   NERduino.begin();
 }
 
-void loop()
-{
+void loop(){
   XYZData_t xyzbuf[NUM_ADXL312_SAMPLES];
   HumidData_t humidbuf[3];
 
@@ -46,8 +45,8 @@ void loop()
     Serial.print(humidbuf[i].relHumid);
     Serial.println(" %RH");
   }
-
+  
   Serial.println("cycle...");
 
-  delay(500);
+  delay(1000);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,5 +52,5 @@ void loop(){
 
   Serial.println("cycle...");
 
-  delay(5000);
+  delay(2000);
 }

--- a/src/nerduino.cpp
+++ b/src/nerduino.cpp
@@ -61,3 +61,9 @@ void NERDUINO::setAMCDutyCycle(uint8_t dutyCycle)
 {
     amc6821.setDutyCycle(dutyCycle);
 }
+
+void NERDUINO::setAMCPWMFreq(pwmfreq_t pwmfreq)
+{
+    amc6821.setPWMFreq(pwmfreq);
+}
+

--- a/src/nerduino.cpp
+++ b/src/nerduino.cpp
@@ -17,7 +17,7 @@ NERDUINO::~NERDUINO(){}
 bool NERDUINO::begin()
 {
     adxl312 = ADXL312();
-    //amc6821 = AMC6821();
+    amc6821 = AMC6821();
     sht30 = SHT30();
 }
 
@@ -55,4 +55,9 @@ void NERDUINO::getSHTdata(HumidData_t *humidbuf, uint8_t numReadings)
     }
 
     delete[] msg;
+}
+
+void NERDUINO::setAMCDutyCycle(uint8_t dutyCycle)
+{
+    amc6821.setDutyCycle(dutyCycle);
 }


### PR DESCRIPTION
PWM API allows duty cycle to be set from the NERduino object. Additional improvements can be made to increase readability of the characteristics register through a defined struct. 