### PR TITLE
Added SPI functions to enable, write to, and write/read from SPI line

### DIFF
--- a/include/nerduino.h
+++ b/include/nerduino.h
@@ -16,6 +16,7 @@
 #include "sht30.h"
 #include "amc6821.h"
 #include "timer.h"
+#include <SPI.h>
 
 //Teensy Pinout
 #define RELAY_PIN       36          //implementation of RELAY_PIN is as simple as digitalWrite(RELAY_PIN,HIGH or LOW);
@@ -34,8 +35,8 @@
 //SPI
 #define SPI1_SCK        13
 #define SPI1_CS         10
-#define SPI1_MISO       11
-#define SPI1_MOSI       12
+#define SPI1_MISO       12
+#define SPI1_MOSI       11
 #define SPI2_SCK        27
 #define SPI2_CS         0
 #define SPI2_MISO       26
@@ -123,6 +124,12 @@ class NERDUINO
         ~NERDUINO();
 
         bool begin();
+
+        void enableSPI1();
+
+        void writeSPI1(uint8_t tx_Data[], uint8_t tx_len, SPISettings settings);
+
+        void writereadSPI1(uint8_t tx_Data[], uint8_t tx_len, uint8_t *rx_data, uint8_t rx_len, SPISettings settings);
 
         /**
          * @brief fills a buffer of data type XYZData_t with XYZ accelerometer data

--- a/src/nerduino.cpp
+++ b/src/nerduino.cpp
@@ -67,3 +67,38 @@ void NERDUINO::setAMCPWMFreq(pwmfreq_t pwmfreq)
     amc6821.setPWMFreq(pwmfreq);
 }
 
+void NERDUINO::enableSPI1()
+{
+    pinMode(SPI1_CS, OUTPUT);
+    digitalWrite(SPI1_CS, HIGH);        //! 1) Pull Chip Select High
+
+    pinMode(SPI1_SCK, OUTPUT);          //! 1) Setup SCK as output
+    pinMode(SPI1_MOSI, OUTPUT);         //! 2) Setup MOSI as output
+    SPI.begin();
+}
+
+void NERDUINO::writeSPI1(uint8_t tx_Data[], uint8_t tx_len, SPISettings settings)
+{
+    SPI.beginTransaction(settings);
+    for (uint8_t i = 0; i < tx_len; i++)
+    {
+        SPI.transfer((int8_t)tx_Data[i]);
+    }
+    SPI.endTransaction();
+}
+
+void NERDUINO::writereadSPI1(uint8_t tx_Data[], uint8_t tx_len, uint8_t *rx_data, uint8_t rx_len, SPISettings settings)
+{
+    SPI.beginTransaction(settings);
+    for (uint8_t i = 0; i < tx_len; i++)
+    {
+        SPI.transfer(tx_Data[i]);
+
+    }
+
+    for (uint8_t i = 0; i < rx_len; i++)
+    {
+        rx_data[i] = (uint8_t)SPI.transfer(0xFF);
+    }
+    SPI.endTransaction();
+}


### PR DESCRIPTION
These are some functions to abstract SPI comms for NERduino. The functions I implemented are:
1. enableSPI1(), defines all the pins and begins SPI on those lines
2. writeSPI1(tx_data, tx_len, settings), writes an array of bytes using the new transaction framework
3. writereadSPI1(tx_data, tx_len, rx_data, rx_len, settings), writes an array of bytes and then immediately reads from the line

The proof of concept for these functions has been tested, I just moved over the code from the LTC SPI functions to NERduino stuff.
Hopefully with this layout, we don't have to enable SPI comms, in case we need to use those lines for something else